### PR TITLE
Support new flag to use collection name as parent suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ newman run <Collection> -e <Environment> -r allure
 $ newman run <Collection> -e <Environment> -r allure --reporter-allure-export <allure-results-out-dir>
 ```
 
+Use the option `--report-allure-collection-as-parent-suite` to use the collection name as the parent suite title under the _Suites_ view. This helps when you run multiple collections and want to aggregate them in a single report.
+
 ## Generating and Serving Allure report
 
 Allure results will be generated under folder "allure-results" in the root location.

--- a/index.js
+++ b/index.js
@@ -178,21 +178,36 @@ class AllureReporter {
         fullName = this.getFullName(this.currentNMGroup);
         var parentSuite, suite;
         var subSuites = [];
+        if(this.reporterOptions.collectionAsParentSuite === true)
+            parentSuite = this.options.collection.name;
         if(fullName !== ''){
-            if(fullName.indexOf('/') > 0 ){
-                const numFolders =  fullName.split("/").length;
-                if(numFolders > 0){
-                    parentSuite = fullName.split("/")[0];
-                    if(numFolders > 1)
-                        suite = fullName.split("/")[1];
-                        if(numFolders > 2)
-                            subSuites =fullName.split("/").slice(2);
+            if(this.reporterOptions.collectionAsParentSuite === true){
+                if(fullName.indexOf('/') > 0 ){
+                    const numFolders = fullName.split("/").length;
+                    if(numFolders > 0){
+                        suite = fullName.split("/")[0];
+                        if(numFolders > 1)
+                            subSuites =fullName.split("/").slice(1);
+                    }
+                } else {
+                    suite = fullName;
                 }
-            } else {
-                parentSuite = fullName;
-            }     
+            }
+            else {
+                if(fullName.indexOf('/') > 0 ){
+                    const numFolders =  fullName.split("/").length;
+                    if(numFolders > 0){
+                        parentSuite = fullName.split("/")[0];
+                        if(numFolders > 1)
+                            suite = fullName.split("/")[1];
+                            if(numFolders > 2)
+                                subSuites =fullName.split("/").slice(2);
+                    }
+                } else {
+                    parentSuite = fullName;
+                }
+            }
         }
-            
         if (parentSuite !== undefined) {
             parentSuite = parentSuite.charAt(0).toUpperCase() + parentSuite.slice(1);
             allure_test.addLabel(LabelName.PARENT_SUITE, parentSuite);


### PR DESCRIPTION
Example:

![MIcSHZPiaD](https://user-images.githubusercontent.com/29582865/109705806-f0213e80-7b76-11eb-98c3-3400bdd38354.gif)

Closes #15